### PR TITLE
Reuse event length defined before

### DIFF
--- a/lib/flow/window.ex
+++ b/lib/flow/window.ex
@@ -450,7 +450,7 @@ defmodule Flow.Window do
     trigger(window, fn -> count end, fn events, acc ->
       length = length(events)
 
-      if length(events) >= acc do
+      if length >= acc do
         {pre, pos} = Enum.split(events, acc)
         {:trigger, name, pre, pos, count}
       else


### PR DESCRIPTION
Didn't measure the difference, but noticed that the length was being
calculated twice, and since that is an operation with linear complexity
I think it's worth the small PR.

Thanks!