### PR TITLE
Add function based partition test

### DIFF
--- a/test/flow_test.exs
+++ b/test/flow_test.exs
@@ -1086,6 +1086,19 @@ defmodule FlowTest do
              |> Enum.sort() == [[1, 2, 4, 5], [3, 6]]
     end
 
+    test "allows function based partitioning" do
+      enumerables = [
+        [%{key: 1, value: 1}, %{key: 2, value: 2}, %{key: 3, value: 3}],
+        [%{key: 1, value: 4}, %{key: 2, value: 5}, %{key: 3, value: 6}]
+      ]
+
+      assert Flow.from_enumerables(enumerables)
+             |> Flow.partition(key: & &1.key, stages: 2)
+             |> Flow.reduce(fn -> [] end, &[&1 | &2])
+             |> Flow.on_trigger(fn acc -> {[acc |> Enum.map(& &1.value) |> Enum.sort()], acc} end)
+             |> Enum.sort() == [[1, 2, 4, 5], [3, 6]]
+    end
+
     test "allows custom windowing" do
       window =
         Flow.Window.fixed(1, :second, fn


### PR DESCRIPTION
This adds a missing test for the option to pass a function that accepts a single argument to `:key` in partition.
