### PR TITLE
ignore stages that don't start

### DIFF
--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -1999,6 +1999,9 @@ defmodule Flow do
 
         {:error, reason} ->
           exit({reason, {__MODULE__, :reduce, [flow, acc, fun]}})
+
+        :ignore ->
+          acc
       end
     end
 

--- a/lib/flow/coordinator.ex
+++ b/lib/flow/coordinator.ex
@@ -26,13 +26,12 @@ defmodule Flow.Coordinator do
     {producers, intermediary} =
       Flow.Materialize.materialize(flow, demand, start_link, type, dispatcher)
 
-    timeout = Keyword.get(options, :subscribe_timeout, 5_000)
-
     producers = for {pid, _} <- producers, pid != :undefined, do: pid
 
     if producers == [] do
       :ignore
     else
+      timeout = Keyword.get(options, :subscribe_timeout, 5_000)
       consumers = consumers.(&start_child(supervisor, &1, []))
 
       for {pid, _} <- intermediary, {consumer, opts} <- consumers do

--- a/test/flow_test.exs
+++ b/test/flow_test.exs
@@ -73,6 +73,18 @@ defmodule FlowTest do
     end
   end
 
+  defmodule NonStarter do
+    use GenStage
+
+    def start_link(_) do
+      GenStage.start_link(__MODULE__, [])
+    end
+
+    def init(_) do
+      :ignore
+    end
+  end
+
   describe "on use" do
     test "defines a child_spec/2 function" do
       defmodule MyFlow do
@@ -1023,6 +1035,15 @@ defmodule FlowTest do
              |> Flow.map(fn x -> x * 2 end)
              |> Enum.take(5)
              |> Enum.sort() == [2, 6, 10, 14, 18]
+    end
+  end
+
+  describe "specs-ignored" do
+    @specs [{NonStarter, []}]
+
+    test "ignores ignored stage" do
+      assert Flow.from_specs(@specs)
+             |> Enum.to_list() == []
     end
   end
 


### PR DESCRIPTION
Closes part of #114.

If you're using `GenStage` specs to start your `Flow` and return `:ignore` from your producer's `GenStage.init/1`, the whole show crashes.

## Proposal

This PR filters out producers that return `{:ok, :undefined}` from their `start_link` and if there are no producers to start, the `Flow.Coordinator.init` will return `:ignore`.  In the event this happens, the `reduce` implementation of `Enumerable` for `Flow` will return the accumulator.

## Notes

Given a `Flow` that doesn't start:

```elixir
defmodule NonStarter do
	use GenStage
		
	def start_link(_) do
	  GenStage.start_link(__MODULE__, [])
	end
		
	def init(_) do
	  :ignore
	end
end
```

Starting the `Flow`, e.g. `Flow.from_specs([{NonStarter, []}]) |> Enum.to_list()`, calls `Flow.reduce/3` , which is part of `Flow`'s implementation of `Enumerable`.  In `reduce`, `Flow` starts its `Coordinator` (a `GenServer`) and then calls `GenStage.stream`, which "creates a stream that subscribes to the given producers and emits the appropriate messages."

In `init` of `Flow.Coordinator` the stages are started using `Supervisor.start_child/3`.  The problem arises in that `Flow` expects an `{:ok, pid()}` result but if our `GenStage` producer returns `:ignore`, then `Supervisor.start_child` returns `{:ok, :undefined}`.  The astute observer will notice that `:undefined` is not a `pid()`.