### PR TITLE
Fix typos and CI errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
     * Ensure flow options effectively override producer dispatcher
 
   * Deprecations
-    * Deprecate `Flow.map/2` and friends after `reduce` to avoid confusion regarding bookeeping of state
+    * Deprecate `Flow.map/2` and friends after `reduce` to avoid confusion regarding bookkeeping of state
 
 ## v1.1.0 (2020-12-09)
 

--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -1578,7 +1578,7 @@ defmodule Flow do
        {"x", 1}]
 
   """
-  @spec reduce(t, (-> acc), (term, acc -> acc)) :: t when acc: term()
+  @spec reduce(t, (() -> acc), (term, acc -> acc)) :: t when acc: term()
   def reduce(flow, acc_fun, reducer_fun) when is_function(reducer_fun, 2) do
     cond do
       has_any_reduce?(flow) ->
@@ -1626,7 +1626,7 @@ defmodule Flow do
       [[1], [1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5]]
 
   """
-  @spec emit_and_reduce(t, (-> acc), (term, acc -> {[event], acc})) :: t
+  @spec emit_and_reduce(t, (() -> acc), (term, acc -> {[event], acc})) :: t
         when acc: term(), event: term()
   def emit_and_reduce(flow, acc_fun, reducer_fun) when is_function(reducer_fun, 2) do
     cond do

--- a/test/flow_test.exs
+++ b/test/flow_test.exs
@@ -156,8 +156,7 @@ defmodule FlowTest do
     end
 
     test "on mapper after emit/1" do
-      message =
-        ~r"map/2 cannot be called after group_by/reduce/emit_and_reduce operation"
+      message = ~r"map/2 cannot be called after group_by/reduce/emit_and_reduce operation"
 
       assert_raise ArgumentError, message, fn ->
         Flow.from_enumerable([1, 2, 3])


### PR DESCRIPTION
Found via `codespell -S deps,.git` and `mix format`